### PR TITLE
Fix cast exception to string

### DIFF
--- a/neuro4j-workflow-core/src/main/java/org/neuro4j/workflow/node/WorkflowNode.java
+++ b/neuro4j-workflow-core/src/main/java/org/neuro4j/workflow/node/WorkflowNode.java
@@ -146,12 +146,12 @@ public class WorkflowNode {
 
 		// if concatenated string
 		if (parts.length > 1) {
-			String stringValue = "";
+			StringBuilder stringValue = new StringBuilder();
 
 			for (String src : parts) {
-				stringValue += (String) ctx.get(src);
+				stringValue.append(ctx.get(src));
 			}
-			obj = stringValue;
+			obj = stringValue.toString();
 
 		} else {
 			obj = ctx.get(source);


### PR DESCRIPTION
An exception will happen if a parameter is no `java.lang.String`.